### PR TITLE
Make end to end specs less brittle

### DIFF
--- a/spec/features/end_to_end_spec.rb
+++ b/spec/features/end_to_end_spec.rb
@@ -80,6 +80,7 @@ RSpec.describe 'end to end', type: :feature, js: true do
 
   def wait_for_ajax
     Timeout.timeout(Capybara.default_max_wait_time) do
+      sleep 0.1
       loop until finished_all_ajax_requests?
     end
   end


### PR DESCRIPTION
Insert a short sleep while waiting for Ajax to ensure all requests
have finished and the select is done updating.