### PR TITLE
Improve appraisal setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ cache:
 
 gemfile:
   - gemfiles/rails_4.2_active_admin_1.0.0.pre4.gemfile
-  - gemfiles/rails_5.1_active_admin_1.0.gemfile
-  - gemfiles/rails_5.1_active_admin_1.1.gemfile
+  - gemfiles/rails_5.1_active_admin_1.x.gemfile
+  - gemfiles/rails_5.x_active_admin_1.x.gemfile
 
 script: bundle exec rspec

--- a/Appraisals
+++ b/Appraisals
@@ -4,12 +4,12 @@ appraise 'rails-4.2-active-admin-1.0.0.pre4' do
   gem 'jquery-ui-rails', '~> 5.0'
 end
 
-appraise 'rails-5.1-active-admin-1.0' do
-  gem 'rails', '~> 5.1'
+appraise 'rails-5.1-active-admin-1.x' do
+  gem 'rails', '~> 5.1.0'
   gem 'activeadmin', '~> 1.0'
 end
 
-appraise 'rails-5.1-active-admin-1.1' do
-  gem 'rails', '~> 5.1'
-  gem 'activeadmin', '~> 1.1'
+appraise 'rails-5.x-active-admin-1.x' do
+  gem 'rails', '~> 5.2'
+  gem 'activeadmin', '~> 1.0'
 end

--- a/activeadmin-searchable_select.gemspec
+++ b/activeadmin-searchable_select.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'appraisal', '~> 2.2'
   spec.add_development_dependency 'rspec-rails', '~> 3.6'
-  spec.add_development_dependency 'combustion', '~> 0.7.0'
+  spec.add_development_dependency 'combustion', '~> 1.0'
   spec.add_development_dependency 'database_cleaner', '~> 1.6'
   spec.add_development_dependency 'sqlite3', '~> 1.3'
   spec.add_development_dependency 'capybara', '~> 2.15'

--- a/gemfiles/rails_5.1_active_admin_1.x.gemfile
+++ b/gemfiles/rails_5.1_active_admin_1.x.gemfile
@@ -3,7 +3,7 @@
 source "https://rubygems.org"
 
 gem "sass-rails"
-gem "rails", "~> 5.1"
+gem "rails", "~> 5.1.0"
 gem "activeadmin", "~> 1.0"
 
 gemspec path: "../"

--- a/gemfiles/rails_5.x_active_admin_1.x.gemfile
+++ b/gemfiles/rails_5.x_active_admin_1.x.gemfile
@@ -3,7 +3,7 @@
 source "https://rubygems.org"
 
 gem "sass-rails"
-gem "rails", "~> 5.1"
-gem "activeadmin", "~> 1.1"
+gem "rails", "~> 5.2"
+gem "activeadmin", "~> 1.0"
 
 gemspec path: "../"


### PR DESCRIPTION
Test against:

* Rails 4.2 legacy setup
* Rails 5.1, Active Admin 1.x
* Rails 5.x, Active Admin 1.x

Update combustion to make it work with newer Rails versions.