### PR TITLE
Support Ruby 3.0 (or versions greater than 2.5)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: ruby
 rvm:
-  - 2.3.4
+  - 2.7
+
 
 # Use container based travis infrastructure which allows caching
 # features for open source projects.

--- a/activeadmin-searchable_select.gemspec
+++ b/activeadmin-searchable_select.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
   spec.files         = `git ls-files -z`.split("\x0")
   spec.require_paths = ['lib']
 
-  spec.required_ruby_version = '~> 2.1'
+  spec.required_ruby_version = '>= 2.5'
 
   spec.add_development_dependency 'bundler', ['>= 1.5', '< 3']
   spec.add_development_dependency 'rake'


### PR DESCRIPTION
Slight tweak to the gemspec so this gem can work with Ruby 3. Since [Ruby 2.4 is now unsupported](https://www.ruby-lang.org/en/news/2020/04/05/support-of-ruby-2-4-has-ended/#:~:text=Now%2C%20after%20one%20year%20has,We%20released%20Ruby%202.4.), I've also tweaked the required ruby version to be 2.5 at the minimum.