### PR TITLE
Make ability to add additional payload of the AJAX response

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,25 @@ build your query in a way that it can query multiple attributes at once.
 
 In this example, the `all` scope will query `email OR username`.
 
+You can add the additional payload as dsl option:
+
+```ruby
+   ActiveAdmin.register Category do
+     searchable_select_options(scope: Category.all,
+                               text_attribute: :name,
+                               additional_payload: ->(record) { { foo: record.bar } } )
+   end
+```
+
+response example which uses additional_payload:
+
+```json
+{
+  "results": [{ "id": "1", "text": "Bicycles", "foo": "Bar" }],
+  "pagination": { "more": "false" }
+}
+```
+
 #### Passing Parameters
 
 You can pass additional parameters to the options endpoint:

--- a/lib/activeadmin/searchable_select/option_collection.rb
+++ b/lib/activeadmin/searchable_select/option_collection.rb
@@ -8,6 +8,7 @@ module ActiveAdmin
         @display_text = extract_display_text_option(options)
         @filter = extract_filter_option(options)
         @per_page = options.fetch(:per_page, 10)
+        @additional_payload = options.fetch(:additional_payload, {})
       end
 
       def scope(template, params)
@@ -38,7 +39,7 @@ module ActiveAdmin
           {
             id: record.id,
             text: display_text(record)
-          }
+          }.merge(hash_of_additional_payload(record) || {})
         end
 
         { results: results, pagination: { more: more } }
@@ -97,6 +98,21 @@ module ActiveAdmin
 
           ->(term, scope) { scope.ransack("#{text_attribute}_cont" => term).result }
         end
+      end
+
+      def build_additional_payload(record)
+        case @additional_payload
+        when Proc
+          @additional_payload.call(record).to_h
+        else
+          {}
+        end
+      end
+
+      def hash_of_additional_payload(record)
+        return nil if @additional_payload.nil? && @additional_payload.empty?
+
+        build_additional_payload(record)
       end
     end
   end

--- a/lib/activeadmin/searchable_select/resource_dsl_extension.rb
+++ b/lib/activeadmin/searchable_select/resource_dsl_extension.rb
@@ -26,6 +26,23 @@ module ActiveAdmin
       #
       # @param name [Symbol] Optional collection name if helper is
       #   used multiple times within one resource.
+      #
+      # @param additional_payload [Proc]
+      #   Adds additional attributes to the results array
+      # @example
+      #
+      #   ActiveAdmin.register Tag do
+      #     searchable_select_options(
+      #       scope: Color,
+      #       text_attributes: :title,
+      #       additional_payload: lambda { |record| { color: record.color } }
+      #     )
+      #   end
+      # @json
+      # {
+      #   "results": [{ "id": "1", "text": "Red", "color": "#FFF" }],
+      #   "pagination": { "more": "false" }
+      # }
       def searchable_select_options(name: :all, **options)
         option_collection = OptionCollection.new(name, options)
         config.searchable_select_option_collections[name] = option_collection

--- a/spec/features/options_dsl_spec.rb
+++ b/spec/features/options_dsl_spec.rb
@@ -140,6 +140,60 @@ RSpec.describe 'searchable_select_options dsl', type: :request do
     end
   end
 
+  describe 'with additional_payload' do
+    context 'as lambda' do
+      before(:each) do
+        ActiveAdminHelpers.setup do
+          ActiveAdmin.register(Post) do
+            searchable_select_options(
+              scope: Post,
+              text_attribute: :title,
+              additional_payload: lambda do |record|
+                { published: record.published }
+              end
+            )
+          end
+        end
+      end
+      let!(:post) { Post.create!(title: 'A post', published: false) }
+
+      subject { get '/admin/posts/all_options' }
+
+      it 'returns options with our additional attribute' do
+        subject
+        expect(json_response).to match(
+          results: [{ text: 'A post', id: post.id, published: false }],
+          pagination: { more: false }
+        )
+      end
+    end
+
+    context 'as Proc' do
+      before(:each) do
+        ActiveAdminHelpers.setup do
+          ActiveAdmin.register(Post) do
+            searchable_select_options(
+              scope: Post,
+              text_attribute: :title,
+              additional_payload: proc { |record| { published: record.published } }
+            )
+          end
+        end
+      end
+      let!(:post) { Post.create!(title: 'A post', published: false) }
+
+      subject { get '/admin/posts/all_options' }
+
+      it 'returns options with our additional attribute' do
+        subject
+        expect(json_response).to match(
+          results: [{ text: 'A post', id: post.id, published: false }],
+          pagination: { more: false }
+        )
+      end
+    end
+  end
+
   it 'allows passing lambda as scope' do
     ActiveAdminHelpers.setup do
       ActiveAdmin.register(Post) do


### PR DESCRIPTION
Solves #32 

Make ability to add additional payload of the AJAX response.
    
At the moment AJAX response contains the following payload: text and id.
But we don't have the ability to add new payload.
So it would be nice to have something like this:

### Usage examples 
 
```
searchable_select_options scope: Post, text_attributes: :tite,
                              additional_payload: lambda do |record|
                                {
                                  custom_field: record.custom_field,
                                  created_at: record.created_at
                                }
                              end
