### PR TITLE
Add option to pass path params for nested resource fetching

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,50 +242,7 @@ argument:
    end
 ```
 
-#### Inlining Ajax Options in Feature Tests
-
-When writing UI driven feature specs (i.e. with Capybara),
-asynchronous loading of select options can increase test
-complexity. `activeadmin-searchable_select` provides an option to
-render all available options just like a normal select input while
-still exercsing the same code paths including `scope` and
-`text_attribute` handling.
-
-For example with RSpec/Capybara, simply set `inline_ajax_options` true
-for feature specs:
-
-```ruby
-  RSpec.configure do |config|
-    config.before(:each) do |example|
-      ActiveAdmin::SearchableSelect.inline_ajax_options = (example.metadata[:type] == :feature)
-    end
-  end
-
-```
-
-### Passing options to Select2
-
-It is possible to pass and define configuration options to Select2
-via `data-attributes` using nested (subkey) options.
-
-Attributes need to be added to the `input_html` option in the form input.
-For example you can tell Select2 how long to wait after a user
-has stopped typing before sending the request:
-
-```ruby
-   ...
-   f.input(:category,
-           as: :searchable_select,
-           ajax: true,
-           input_html: {
-             data: {
-               'ajax--delay' => 500
-             }
-           })
-   ...
-```
-
-### Path options for nested resources
+#### Path options for nested resources
 
 Example for the following setup:
 
@@ -333,16 +290,61 @@ ActiveAdmin.register(Variant) do
     ...
     f.input(:option_value,
             as: :searchable_select,
-            path_params: {
-              option_type_id: f.object.product.option_type_id
-            },
-            ajax: { resource: OptionValue })
+            ajax: {
+              resource: OptionValue,
+              path_params: {
+                option_type_id: f.object.product.option_type_id
+              }
+            })
     ...
   end
 end
 ```
 
 This will generate the path for fetching as `all_options_admin_option_type_option_values(option_type_id: f.object.product.option_type_id)` (e.g. `/admin/option_types/2/option_values/all_options`)
+
+#### Inlining Ajax Options in Feature Tests
+
+When writing UI driven feature specs (i.e. with Capybara),
+asynchronous loading of select options can increase test
+complexity. `activeadmin-searchable_select` provides an option to
+render all available options just like a normal select input while
+still exercsing the same code paths including `scope` and
+`text_attribute` handling.
+
+For example with RSpec/Capybara, simply set `inline_ajax_options` true
+for feature specs:
+
+```ruby
+  RSpec.configure do |config|
+    config.before(:each) do |example|
+      ActiveAdmin::SearchableSelect.inline_ajax_options = (example.metadata[:type] == :feature)
+    end
+  end
+
+```
+
+### Passing options to Select2
+
+It is possible to pass and define configuration options to Select2
+via `data-attributes` using nested (subkey) options.
+
+Attributes need to be added to the `input_html` option in the form input.
+For example you can tell Select2 how long to wait after a user
+has stopped typing before sending the request:
+
+```ruby
+   ...
+   f.input(:category,
+           as: :searchable_select,
+           ajax: true,
+           input_html: {
+             data: {
+               'ajax--delay' => 500
+             }
+           })
+   ...
+```
 
 
 ## Development

--- a/lib/activeadmin/searchable_select/select_input_extension.rb
+++ b/lib/activeadmin/searchable_select/select_input_extension.rb
@@ -45,7 +45,7 @@ module ActiveAdmin
 
       def ajax_url
         return unless options[:ajax]
-        [ajax_resource.route_collection_path,
+        [ajax_resource.route_collection_path(path_params),
          '/',
          option_collection.collection_action_name,
          '?',
@@ -122,6 +122,10 @@ module ActiveAdmin
 
       def ajax_params
         ajax_options.fetch(:params, {})
+      end
+
+      def path_params
+        options[:path_params]
       end
 
       def ajax_options

--- a/lib/activeadmin/searchable_select/select_input_extension.rb
+++ b/lib/activeadmin/searchable_select/select_input_extension.rb
@@ -20,6 +20,10 @@ module ActiveAdmin
     # - `params`: Hash of query parameters that shall be passed to the
     #   options endpoint.
     #
+    # - `path_params`: Hash of parameters, which would be passed to the
+    #   dynamic collection path generation for the resource.
+    #   e.g `admin_articles_path(path_params)`
+    #
     # If the `ajax` option is present, the `collection` option is
     # ignored.
     module SelectInputExtension
@@ -125,7 +129,7 @@ module ActiveAdmin
       end
 
       def path_params
-        options[:path_params]
+        ajax_options.fetch(:path_params, {})
       end
 
       def ajax_options

--- a/spec/features/end_to_end_spec.rb
+++ b/spec/features/end_to_end_spec.rb
@@ -95,7 +95,7 @@ RSpec.describe 'end to end', type: :feature, js: true do
   end
 
   context 'class with nested belongs_to association' do
-    before(:each) do
+    before(:all) do
       ActiveAdminHelpers.setup do
         ActiveAdmin.register(OptionType)
 
@@ -118,9 +118,11 @@ RSpec.describe 'end to end', type: :feature, js: true do
             input :price
             input(:option_value,
                   as: :searchable_select,
-                  path_params: { option_type_id: f.object.product.option_type_id },
                   ajax: {
-                    resource: OptionValue
+                    resource: OptionValue,
+                    path_params: {
+                      option_type_id: f.object.product.option_type_id
+                    }
                   })
           end
         end

--- a/spec/features/end_to_end_spec.rb
+++ b/spec/features/end_to_end_spec.rb
@@ -94,6 +94,92 @@ RSpec.describe 'end to end', type: :feature, js: true do
     end
   end
 
+  context 'class with nested belongs_to association' do
+    before(:each) do
+      ActiveAdminHelpers.setup do
+        ActiveAdmin.register(OptionType)
+
+        ActiveAdmin.register(Product)
+
+        ActiveAdmin.register(OptionValue) do
+          belongs_to :option_type
+          searchable_select_options(scope: lambda do |params|
+                                             OptionValue.where(
+                                               option_type_id: params[:option_type_id]
+                                             )
+                                           end,
+                                    text_attribute: :value)
+        end
+
+        ActiveAdmin.register(Variant) do
+          belongs_to :product
+
+          form do |f|
+            input :price
+            input(:option_value,
+                  as: :searchable_select,
+                  path_params: { option_type_id: f.object.product.option_type_id },
+                  ajax: {
+                    resource: OptionValue
+                  })
+          end
+        end
+
+        ActiveAdmin.setup {}
+      end
+    end
+
+    describe 'new page with searchable select filter' do
+      it 'loads filter input options' do
+        option_type = OptionType.create(name: 'Color')
+        ot = OptionType.create(name: 'Size')
+        OptionValue.create(value: 'Black', option_type: option_type)
+        OptionValue.create(value: 'Orange', option_type: option_type)
+        OptionValue.create(value: 'M', option_type: ot)
+        product = Product.create(name: 'Cap', option_type: option_type)
+
+        visit "/admin/products/#{product.id}/variants/new"
+
+        expand_select_box
+        wait_for_ajax
+
+        expect(select_box_items).to eq(%w(Black Orange))
+      end
+
+      it 'allows filtering options by term' do
+        option_type = OptionType.create(name: 'Color')
+        ot = OptionType.create(name: 'Size')
+        OptionValue.create(value: 'Black', option_type: option_type)
+        OptionValue.create(value: 'Orange', option_type: option_type)
+        OptionValue.create(value: 'M', option_type: ot)
+        product = Product.create(name: 'Cap', option_type: option_type)
+
+        visit "/admin/products/#{product.id}/variants/new"
+
+        expand_select_box
+        enter_search_term('O')
+        wait_for_ajax
+
+        expect(select_box_items).to eq(%w(Orange))
+      end
+
+      it 'loads more items when scrolling down' do
+        option_type = OptionType.create(name: 'Color')
+        15.times { |i| OptionValue.create(value: "Black #{i}", option_type: option_type) }
+        product = Product.create(name: 'Cap', option_type: option_type)
+
+        visit "/admin/products/#{product.id}/variants/new"
+
+        expand_select_box
+        wait_for_ajax
+        scroll_select_box_list
+        wait_for_ajax
+
+        expect(select_box_items.size).to eq(15)
+      end
+    end
+  end
+
   def expand_select_box
     find('.select2-container').click
   end

--- a/spec/internal/db/schema.rb
+++ b/spec/internal/db/schema.rb
@@ -31,6 +31,26 @@ ActiveRecord::Schema.define do
     t.integer :color_id
   end
 
+  create_table(:option_types, force: true) do |t|
+    t.string :name
+  end
+
+  create_table(:option_values, force: true) do |t|
+    t.string :value
+    t.belongs_to :option_type
+  end
+
+  create_table(:products, force: true) do |t|
+    t.string :name
+    t.belongs_to :option_type
+  end
+
+  create_table(:variants, force: true) do |t|
+    t.integer :price
+    t.belongs_to :product
+    t.belongs_to :option_value
+  end
+
   create_table(:users, force: true) do |t|
     t.string :name
   end

--- a/spec/support/active_admin_helpers.rb
+++ b/spec/support/active_admin_helpers.rb
@@ -2,7 +2,7 @@ module ActiveAdminHelpers
   module_function
 
   def setup
-    ActiveAdmin.application = nil
+    ActiveAdmin.unload!
     yield
     Rails.application.reload_routes!
   end

--- a/spec/support/active_admin_helpers.rb
+++ b/spec/support/active_admin_helpers.rb
@@ -1,9 +1,13 @@
 module ActiveAdminHelpers
   module_function
 
-  def setup
-    ActiveAdmin.unload!
-    yield
+  def reload_routes!
     Rails.application.reload_routes!
+  end
+
+  def setup
+    ActiveAdmin.application = nil
+    yield
+    reload_routes!
   end
 end

--- a/spec/support/models.rb
+++ b/spec/support/models.rb
@@ -27,6 +27,22 @@ module Internal
   end
 end
 
+class OptionType < ActiveRecord::Base; end
+
+class OptionValue < ActiveRecord::Base
+  belongs_to :option_type
+end
+
+class Product < ActiveRecord::Base
+  belongs_to :option_type
+  has_many :variants
+end
+
+class Variant < ActiveRecord::Base
+  belongs_to :product
+  belongs_to :option_value
+end
+
 RSpec.configure do |config|
   config.after do
     DatabaseCleaner.strategy = :truncation


### PR DESCRIPTION
* Added the optional passing of parameters to the path generating via `path_params`

```ruby
...
    f.input(:option_value,
            as: :searchable_select,
            ajax: { 
              resource: OptionValue,
              path_params: {
                option_type_id: f.object.product.option_type_id
              }
            })
...
```

When fetching records of nested resources, which are only available under the sub-directory path(e.g. `/option_type/:option_type_id/option_values`), it is now possible to pass path params and correctly generate the URL for fetching the given resources.

Before this change, an error would be raised because no `option_type_id` is provided to the path.

~~* Fix spec warnings for 'method already defined' because of double loading of `ActiveAdmin` resources. It is done by using `ActiveAdmin.unload!` which correctly unloads the resources.~~