### PR TITLE
Add NPM module support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # ActiveAdmin Searchable Select
 
 [![Gem Version](https://badge.fury.io/rb/activeadmin-searchable_select.svg)](http://badge.fury.io/rb/activeadmin-searchable_select)
+[![NPM Version](https://badge.fury.io/js/@codevise%2Factiveadmin-searchable_select.svg)](https://badge.fury.io/js/@codevise%2Factiveadmin-searchable_select)
+![npm](https://img.shields.io/npm/dm/@codevise/activeadmin-searchable_select)
 [![Build Status](https://github.com/codevise/activeadmin-searchable_select.svg?branch=master)](https://github.com/codevise/activeadmin-searchable_select/actions)
 
 Searchable select boxes (via [Select2](https://select2.org/)) for
@@ -15,6 +17,7 @@ Add `activeadmin-searchable_select` to your Gemfile:
    gem 'activeadmin-searchable_select'
 ```
 
+##### Using assets via Sprockets
 Import stylesheets and require javascripts:
 
 ```scss
@@ -25,6 +28,39 @@ Import stylesheets and require javascripts:
 ```coffee
 // active_admin.js
 //= require active_admin/searchable_select
+```
+
+##### Using assets via Webpacker (or any other assets bundler) as a NPM module (Yarn package)
+
+Execute:
+
+    $ npm i @codevise/activeadmin-searchable_select
+
+Or
+
+    $ yarn add @codevise/activeadmin-searchable_select
+
+Or add manually to `package.json`:
+
+```json
+"dependencies": {
+  "@codevise/activeadmin-searchable_select": "1.6.0"
+}
+```
+and execute:
+
+    $ yarn
+
+Add the following line into `app/assets/javascripts/active_admin.js`:
+
+```javascript
+import '@codevise/activeadmin-searchable_select';
+```
+
+Add the following line into `app/assets/stylesheets/active_admin.scss`:
+
+```css
+@import '@codevise/activeadmin-searchable_select';
 ```
 
 ## Usage

--- a/app/assets/javascripts/active_admin/searchable_select_pack.js
+++ b/app/assets/javascripts/active_admin/searchable_select_pack.js
@@ -1,0 +1,2 @@
+import 'select2';
+import './searchable_select/init';

--- a/package.json
+++ b/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "@codevise/activeadmin-searchable_select",
+  "version": "1.6.0",
+  "description": "Use searchable selects based on Select2 in Active Admin forms and filters.",
+  "main": "src/searchable_select.js",
+  "style": "src/searchable_select.scss",
+  "repository": "git@github.com:codevise/activeadmin-searchable_select.git",
+  "author": "Codevise Solutions Ltd <info@codevise.de>",
+  "license": "MIT",
+  "private": false,
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/codevise/activeadmin-searchable_select.git"
+  },
+  "bugs": {
+    "url": "https://github.com/codevise/activeadmin-searchable_select/issues"
+  },
+  "homepage": "https://github.com/codevise/activeadmin-searchable_select#readme",
+  "keywords": [
+    "select2",
+    "active",
+    "admin",
+    "searchable",
+    "select"
+  ],
+  "dependencies": {
+    "jquery": ">= 3.0, < 5",
+    "select2": "~> 4.0"
+  },
+  "files": [
+    "src/**/*"
+  ],
+  "scripts": {
+    "prepare_javascripts_src": "rm -rf src && cp -R app/assets/javascripts/active_admin/ src && mv src/searchable_select_pack.js src/searchable_select.js",
+    "prepare_stylesheets_src": "cp -R app/assets/stylesheets/active_admin/ src",
+    "prepublishOnly": "npm run prepare_javascripts_src && npm run prepare_stylesheets_src"
+  }
+}


### PR DESCRIPTION
This PR adds support to use this repo as an NPM/Yarn package so we can use it with Webpacker or any other assets bundler.
I implemented this so it uses the same source files as the Rails gem so any change in the JS and CSS is available in both cases. I didn't change the Rails gem-related code this same repo can be used in both ways. The separate entry point `searchable_select_pack.js` is needed to support the `import` (ES6 syntax).

After pack&publish NPM module has minimum files and should look like:
![NPM package](https://user-images.githubusercontent.com/22831505/172147843-aec591c8-af46-4c60-8463-18032cc2f692.png)

How you can test the package locally before merge&publish:
1. Fetch the current branch on your local machine;
2. Open `package.json` and replace in scripts sections `prepublishOnly` on `prepack`;
3. Execute in console `npm pack` (you should have installed Node.js)
4. Follow to target project where you want to use current gem (gem should be already installed) with assets from package and execute: `yarn add /path-to-local-project-repository/activeadmin-searchable_select`, where `path-to-local-project-repository` is full path in your system (example: `/Users/username/workspace/activeadmin-searchable_select`), or relative path (example: `../activeadmin-searchable_select`);
5. Add the following line `import '@codevise/activeadmin-searchable_select'` into `app/assets/javascripts/active_admin.js` or any other entry point file for javascripts in your project.
6. Add the following line `@import '@codevise/activeadmin-searchable_select';` into `app/assets/stylesheets/active_admin.scss` or any other entry point file for stylesheets in your project.
7. Make sure about assets via Sprockets is not enabled (`//= require active_admin/searchable_select` etc..);
8. To remove package execute `yarn remove @codevise/activeadmin-searchable_select`.

After the PR is merged, you can run `npm publish --access public` ([Instruction](https://docs.npmjs.com/creating-and-publishing-scoped-public-packages#publishing-scoped-public-packages)) from master branch to publish scoped NPM package on the https://www.npmjs.com/, or I can do it myself.

Resolve https://github.com/codevise/activeadmin-searchable_select/issues/35