### PR TITLE
Fix pre-selected item when using belongs_to

### DIFF
--- a/lib/activeadmin/searchable_select/select_input_extension.rb
+++ b/lib/activeadmin/searchable_select/select_input_extension.rb
@@ -84,7 +84,7 @@ module ActiveAdmin
       end
 
       def option_collection_scope
-        option_collection.scope(template, ajax_params)
+        option_collection.scope(template, path_params.merge(ajax_params))
       end
 
       def option_collection

--- a/spec/features/ajax_params_spec.rb
+++ b/spec/features/ajax_params_spec.rb
@@ -50,4 +50,52 @@ RSpec.describe 'ajax params', type: :request do
     expect(response.body).to have_selector('.searchable-select-input' \
                                            "[data-ajax-url*='#{url_matcher}']")
   end
+
+  context 'when using belongs_to' do
+    before(:each) do
+      ActiveAdminHelpers.setup do
+
+        ActiveAdmin.register(OptionType)
+
+        ActiveAdmin.register(Product) do
+
+        ActiveAdmin.register(OptionValue) do
+          belongs_to :option_type
+          searchable_select_options(scope: lambda do |params|
+                                            OptionValue.where(
+                                              option_type_id: params[:option_type_id]
+                                            )
+                                          end,
+                                    text_attribute: :value)
+        end
+
+        ActiveAdmin.register(Variant) do
+          belongs_to :product
+        
+          form do |f|
+            f.input(:option_value,
+                    as: :searchable_select,
+                    ajax: {
+                      resource: OptionValue,
+                      path_params: {
+                        option_type_id: f.object.product.option_type_id
+                      }
+                    })
+          end
+        end
+      end
+    end
+
+    it 'pre-select items in the associations' do 
+      option_type = OptionType.create
+      product = Product.create(option_type: option_type)
+      option_value = OptionValue.create(option_type: option_type, value: 'Red')
+      variant = Variant.create(product: product, option_value: option_value)
+
+      get "/admin/products/#{product.id}/variants/#{variant.id}/edit"
+  
+      expect(response.body).to have_selector('.searchable-select-input option[selected]',
+        count: 1)
+    end
+  end
 end


### PR DESCRIPTION
Thanks for the great lib! 
We use it a lot in our application and found a small issue when using [belongs_to](https://activeadmin.info/2-resource-customization.html#belongs-to) in active admin.

-> To make `belongs_to` works with the lib, we have to add `path_params` in the `ajax` options (as described [here](https://github.com/codevise/activeadmin-searchable_select#path-options-for-nested-resources)). But this example doesn't work when the Model already have a value (it is not preselected). It works well for subsequent search.

-> This is because https://github.com/codevise/activeadmin-searchable_select/blob/master/lib/activeadmin/searchable_select/select_input_extension.rb#L87 is taking into account only the `params` and not the `path_params` during initial load.

----

In our code, to fix it we had to add it twice, which we guess is not intended: 

```
            f.input(:option_value,
                    as: :searchable_select,
                    ajax: {
                      resource: OptionValue,
                      path_params: {
                        option_type_id: f.object.product.option_type_id
                      },
					 params: {
					  option_type_id: f.object.product.option_type_id
					}
                    })
```

cc @ChrLec 