### PR TITLE
Update webdrivers to fix specs for Chrome 115

### DIFF
--- a/activeadmin-searchable_select.gemspec
+++ b/activeadmin-searchable_select.gemspec
@@ -26,8 +26,8 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency 'capybara', '~> 3.9'
   spec.add_development_dependency 'puma', '~> 5.0'
-  spec.add_development_dependency 'selenium-webdriver', '~> 3.6'
-  spec.add_development_dependency 'webdrivers', '~> 4.0'
+  spec.add_development_dependency 'selenium-webdriver', '~> 4.1'
+  spec.add_development_dependency 'webdrivers', '= 5.3.0'
 
   spec.add_development_dependency 'coffee-rails'
   spec.add_development_dependency 'rails'


### PR DESCRIPTION
With the introduction of Chrome for Testing, download locations for drivers changed. According to the `webdrivers` readme [1], we can upgrade to `selenium-webdrivers` 4.11 once we drop support Ruby 2 and remove the `webdrivers` gem completely. For now we upgrade to a version of `webdrivers` that supports the new setup.

[1] https://github.com/titusfortner/webdrivers/blob/v5.3.1/README.md#update-future-of-this-project

REDMINE-20419